### PR TITLE
Update XXXRoundMenuButton.h

### DIFF
--- a/Views/XXXRoundMenuButton.h
+++ b/Views/XXXRoundMenuButton.h
@@ -50,7 +50,7 @@ typedef NS_OPTIONS(NSInteger, XXXIconType) {
  *  @param degree       start degree
  *  @param layoutDegree angle span
  */
-- (void)loadButtonWithIcons:(NSArray<UIImage*>*)icons startDegree:(double)degree layoutDegree:(double)layoutDegree;
+- (void)loadButtonWithIcons:(NSArray<UIImage*>*)icons startDegree:(CGFloat)degree layoutDegree:(CGFloat)layoutDegree;
 
 /**
  *  click block


### PR DESCRIPTION
Patch on warning on method declaration. 
This warning causes error on display  (every item at the same place) (conversion between double and CGFloat failed)
